### PR TITLE
Bumps version to reflect README changes

### DIFF
--- a/srfi-133.meta
+++ b/srfi-133.meta
@@ -10,7 +10,7 @@
         "srfi-133.meta"
         "srfi-133.release-info"
         "LICENSE"
-        "README.md")
+        "README.org")
 
  (license "BSD")
  (category data)

--- a/srfi-133.release-info
+++ b/srfi-133.release-info
@@ -1,3 +1,4 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.1")
 (release "1.0")

--- a/srfi-133.setup
+++ b/srfi-133.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-133
  `(,(dynld-name "srfi-133") ,(dynld-name "srfi-133.import"))
- '((version "1.0")))
+ '((version "1.1")))


### PR DESCRIPTION
This should correspond to a tag for `CHICKEN-1.1`.

I merely bumped the version here to reflect the new README distributed with the SRFI.
