### PR TITLE
Errata for vector-cumulate

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,12 @@
   <head>
     <title>Vector Library (R7RS-compatible)</title>
     <link href="../admin.css" rel="stylesheet">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   </head>
 
   <body>
     <h1>SRFI 133: Vector Library (R7RS-compatible)</h1>
-    <h2>John Cowan (based on SRFI 43 by Taylor Campbell)</h2>
+    <h2>by John Cowan (based on SRFI 43 by Taylor Campbell)</h2>
 
     <menu>
       <li><a href="srfi-133.html">The SRFI Document</a></li>

--- a/srfi-133.html
+++ b/srfi-133.html
@@ -92,7 +92,7 @@ None at this time.
       <li>Draft #3 published: 2016/1/31</li>
       <li>Draft #4 published: 2016/3/12</li>
       <li>Finalized: 2016/3/20</li>
-      <li>Revised to fix erratum: 2016/4/1</li>
+      <li>Revised to fix errata: 2016/4/1, 2016/8/10</li>
     </ul>
 
     <h1 class="nonheader"><a name="Abstract">2. Abstract</a></h1>

--- a/srfi-133.html
+++ b/srfi-133.html
@@ -1464,7 +1464,7 @@ zot</pre>
     <dl>
       <dt class="proc-spec">
         <a name="vector-cumulate">
-          (vector-cumulate <i>f vec knil</i>)
+          (vector-cumulate <i>f knil vec</i>)
           -&gt; vector
         </a>
       </dt>

--- a/vectors/vectors-impl.scm
+++ b/vectors/vectors-impl.scm
@@ -917,13 +917,13 @@
                                           vector-count)
                         (cons vec vectors)))))
 
-;;; (VECTOR-CUMULATE <f> <vector> <knil>)
+;;; (VECTOR-CUMULATE <f> <knil> <vector>)
 ;;;       -> vector
 ;;;   Returns a <new>ly allocated vector <new> with the same length as
 ;;;   <vec>. Each element <i> of <new> is set to the result of invoking <f> on
 ;;;   <new>[i-1] and <vec>[i], except that for the first call on <f>, the first
 ;;;   argument is <knil>. The <new> vector is returned.
-(define (vector-cumulate f vec knil)
+(define (vector-cumulate f knil vec)
   (let* ((len (vector-length vec))
          (result (make-vector len)))
     (let loop ((i 0) (left knil))


### PR DESCRIPTION
Hey Arthur, I've talked to John and we discussed that `vector-cumulate` should have the same signature as `vector-fold` and `fold` in terms of argument order. Basically the problem was that `vector-cumulate` had the following signature:

``` scheme
(vector-cumulate proc vec knil)
```

when it should have had the signature

``` scheme
(vector-cumulate proc knil vec)
```

This is more consistent, since "cumulate" is just accumulating the step-wise results of a fold into a single collection; therefore, it makes sense to be able to swap out `fold`s and `cumulate`s without changing the remaining order of arguments. John already pre-approved this as an errata (see attached image) and I've made the correct changes to both SRFI docs and code. I don't think this should impact people too much, as it only rearranges the argument order and is otherwise a very minor errata to distribute. Thanks again for all the help. 

![capture](https://cloud.githubusercontent.com/assets/5060863/18219201/1f3b42ee-7125-11e6-9710-63b3f3f777b5.png)
