### PR TITLE
Fix a mistake in the comment for vector=

### DIFF
--- a/vectors/vectors-impl.scm
+++ b/vectors/vectors-impl.scm
@@ -705,8 +705,8 @@
 ;;;     (ELT=? <value> <value>) -> boolean
 ;;;   Determine vector equality generalized across element comparators.
 ;;;   Vectors A and B are equal iff their lengths are the same and for
-;;;   each respective elements E_a and E_b (element=? E_a E_b) returns
-;;;   a true value.  ELT=? is always applied to two arguments.
+;;;   each respective elements E_a and E_b (elt=? E_a E_b) returns a
+;;;   true value.  ELT=? is always applied to two arguments.
 ;;;
 ;;;   If the number of vector arguments is zero or one, then #T is
 ;;;   automatically returned.  If there are N vector arguments,


### PR DESCRIPTION
`elt=?` is the name of the comparator, not `element=?`.

The SRFI text, the code and part of the comment all use `elt=?`, but there was a reference to `element=?` in the comment.